### PR TITLE
add optional wrtc support

### DIFF
--- a/index-browser.js
+++ b/index-browser.js
@@ -24,7 +24,7 @@ var AudioContext = window.webkitAudioContext || window.AudioContext;
 // export support flags and constructors.prototype && PC
 module.exports = {
     support: !!PC,
-    dataChannel: isChrome || isFirefox || (PC && PC.prototype && PC.prototype.createDataChannel),
+    dataChannel: !!(PC && PC.prototype && PC.prototype.createDataChannel),
     prefix: prefix,
     webAudio: !!(AudioContext && AudioContext.prototype.createMediaStreamSource),
     mediaStream: !!(MediaStream && MediaStream.prototype.removeTrack),

--- a/index-node.js
+++ b/index-node.js
@@ -1,15 +1,20 @@
-// Once node.js gains a robust module integrating WebRTC that can
-// be easily added to dependencies, we'll update this to expose it
+try {
+    var wrtc = require('wrtc');
+} catch (er) {
+    var wrtc = null;
+}
+
+var PC = wrtc && wrtc.RTCPeerConnection;
 
 module.exports = {
-    support: false,
+    support: !!PC,
+    dataChannel: !!(PC && PC.prototype && PC.prototype.createDataChannel),
     prefix: undefined,
-    dataChannel: false,
-    webAudio: false,
-    mediaStream: false,
+    webAudio: !!(wrtc.RTCAudioContext && wrtc.RTCAudioContext.prototype.createMediaStreamSource),
+    mediaStream: !!(wrtc.MediaStream && wrtc.MediaStream.prototype.removeTrack),
     screenSharing: false,
-    AudioContext: undefined,
-    PeerConnection: undefined,
-    SessionDescription: undefined,
-    IceCandidate: undefined
+    AudioContext: wrtc.RTCAudioContext,
+    PeerConnection: PC,
+    SessionDescription: wrtc.RTCSessionDescription,
+    IceCandidate: wrtc.RTCIceCandidate
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "browserify": "2.22.0",
     "precommit-hook": "0.3.x"
   },
+  "optionalDependencies": {
+    "wrtc": "~0.0.22"
+  },
   "keywords": [
     "browser",
     "WebRTC"

--- a/webrtcsupport.bundle.js
+++ b/webrtcsupport.bundle.js
@@ -19,14 +19,14 @@ var PC = window.mozRTCPeerConnection || window.webkitRTCPeerConnection;
 var IceCandidate = window.mozRTCIceCandidate || window.RTCIceCandidate;
 var SessionDescription = window.mozRTCSessionDescription || window.RTCSessionDescription;
 var MediaStream = window.webkitMediaStream || window.MediaStream;
-var screenSharing = window.navigator.userAgent.match('Chrome') && parseInt(window.navigator.userAgent.match(/Chrome\/(.*) /)[1], 10) >= 26;
+var screenSharing = window.location.protocol === 'https:' && window.navigator.userAgent.match('Chrome') && parseInt(window.navigator.userAgent.match(/Chrome\/(.*) /)[1], 10) >= 26;
 var AudioContext = window.webkitAudioContext || window.AudioContext;
 
 
 // export support flags and constructors.prototype && PC
 module.exports = {
     support: !!PC,
-    dataChannel: isChrome || isFirefox || (PC && PC.prototype && PC.prototype.createDataChannel),
+    dataChannel: !!(PC && PC.prototype && PC.prototype.createDataChannel),
     prefix: prefix,
     webAudio: !!(AudioContext && AudioContext.prototype.createMediaStreamSource),
     mediaStream: !!(MediaStream && MediaStream.prototype.removeTrack),


### PR DESCRIPTION
I wouldn't say wrtc is "easily added to dependencies", but it's entirely possible to build for those that really want it.

I've added it as an optional dependency, and updated the index-node.js to reflect the supported features.
