### PR TITLE
Remove old support

### DIFF
--- a/index-browser.js
+++ b/index-browser.js
@@ -30,11 +30,6 @@ module.exports = {
     supportWebAudio: !!(AudioContext && AudioContext.prototype.createMediaStreamSource),
     supportMediaStream: !!(MediaStream && MediaStream.prototype.removeTrack),
     supportScreenSharing: !!screenSharing,
-    // old deprecated style. Dont use this anymore
-    dataChannel: !!(PC && PC.prototype && PC.prototype.createDataChannel),
-    webAudio: !!(AudioContext && AudioContext.prototype.createMediaStreamSource),
-    mediaStream: !!(MediaStream && MediaStream.prototype.removeTrack),
-    screenSharing: !!screenSharing,
     // constructors
     AudioContext: AudioContext,
     PeerConnection: PC,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webrtcsupport",
   "description": "Browser module to detect support for webrtc and extract proper constructors.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "browser": "index-browser.js",
   "devDependencies": {

--- a/webrtcsupport.bundle.js
+++ b/webrtcsupport.bundle.js
@@ -31,11 +31,6 @@ module.exports = {
     supportWebAudio: !!(AudioContext && AudioContext.prototype.createMediaStreamSource),
     supportMediaStream: !!(MediaStream && MediaStream.prototype.removeTrack),
     supportScreenSharing: !!screenSharing,
-    // old deprecated style. Dont use this anymore
-    dataChannel: !!(PC && PC.prototype && PC.prototype.createDataChannel),
-    webAudio: !!(AudioContext && AudioContext.prototype.createMediaStreamSource),
-    mediaStream: !!(MediaStream && MediaStream.prototype.removeTrack),
-    screenSharing: !!screenSharing,
     // constructors
     AudioContext: AudioContext,
     PeerConnection: PC,


### PR DESCRIPTION
this removes the old style, major version needs to go to 2.0.0 

@dagingaa: I should have done that immediately after merging.