### PR TITLE
Remove VP8 requirement

### DIFF
--- a/index-browser.js
+++ b/index-browser.js
@@ -26,7 +26,7 @@ var getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || nav
 module.exports = {
     prefix: prefix,
     browserVersion: version,
-    support: !!PC && supportVp8 && !!getUserMedia,
+    support: !!PC && !!getUserMedia,
     // new support style
     supportRTCPeerConnection: !!PC,
     supportVp8: supportVp8,


### PR DESCRIPTION
In some browser, such as [Bowser](https://github.com/EricssonResearch/bowser), video playback is not the same as
WebRTC video support.
