### PR TITLE
Browser version detection fix

### DIFF
--- a/index-browser.js
+++ b/index-browser.js
@@ -4,10 +4,10 @@ var version;
 
 if (window.mozRTCPeerConnection || navigator.mozGetUserMedia) {
     prefix = 'moz';
-    version = parseInt(navigator.userAgent.match(/Firefox\/([0-9]+)\./)[1], 10);
+    version = parseInt((navigator.userAgent.match(/Firefox\/([0-9]+)\./) || [0, 0])[1], 10);
 } else if (window.webkitRTCPeerConnection || navigator.webkitGetUserMedia) {
     prefix = 'webkit';
-    version = navigator.userAgent.match(/Chrom(e|ium)/) && parseInt(navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./)[2], 10);
+    version = parseInt((navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./) || [0, 0, 0])[2], 10);
 }
 
 var PC = window.RTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webrtcsupport",
   "description": "Browser module to detect support for webrtc and extract proper constructors.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "browser": "index-browser.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webrtcsupport",
   "description": "Browser module to detect support for webrtc and extract proper constructors.",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "browser": "index-browser.js",
   "devDependencies": {


### PR DESCRIPTION
Fix for a production error email I've been seeing, `TypeError: navigator.userAgent.match(...) is null` from a client that identifies as Safari 9.1.2. I couldn't reproduce the problem in Safari 9 myself, so I'm guessing that it's Firefox with a user agent randomiser.

Also included minor cleanup to avoid running redundant regex matches.